### PR TITLE
Add text-creation form to HTML template

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -53,6 +53,10 @@ func main() {
 		rendererKeys = append(rendererKeys, k)
 	}
 
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.Redirect("/texts")
+	})
+
 	// List all texts.
 	app.Get("/texts", func(c *fiber.Ctx) error {
 		texts, err := cfg.App.List()

--- a/pkg/render/html.go
+++ b/pkg/render/html.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"time"
 
 	"github.com/lukasschwab/tiir/pkg/text"
 )
@@ -13,66 +12,15 @@ import (
 //go:embed templates/html.tmpl
 var htmlTemplate string
 
-// HTML table rendering for texts, grouped by [text.Text.Timestamp]. HTML
-// assumes texts it receives are already ordered by timestamp, descending; see
-// [text.Sort].
-//
-// Example output:
-//
-//	<head>
-//		<!-- Head contents... -->
-//	</head>
-//	<h1 class="title">tir</h1>
-//	<p><a href="https://github.com/lukasschwab/tiir">GitHub</a></p>
-//	<hr/>
-//	<table class="table">
-//		<tr>
-//			<th>Title</th>
-//			<th>Author</th>
-//			<th>Note</th>
-//			<th>Date</th>
-//		</tr>
-//		<td colspan="4"><h3>April 7, 2023</h3></td>
-//		<tr>
-//			<td><a href="https://davidchall.github.io/ggip/articles/visualizing-ip-data.html">Visualizing IP data</a></td>
-//			<td>David Hall</td>
-//			<td>Use a Hilbert Curve: efficient 2D packing that keeps consecutive sequences spatially contiguous.</td>
-//			<td>2023-04-07</td>
-//		</tr>
-//		<!-- More rows... -->
-//	</table>
+// HTML table rendering for texts. HTML assumes texts it receives are already
+// ordered by timestamp, descending; see [text.Sort].
 func HTML(texts []*text.Text, to io.Writer) error {
 	tmpl, err := template.New("html").Parse(htmlTemplate)
 	if err != nil {
 		return fmt.Errorf("error parsing template: %w", err)
 	}
-	if err := tmpl.Execute(to, byDate(texts)); err != nil {
+	if err := tmpl.Execute(to, texts); err != nil {
 		return fmt.Errorf("error executing template: %w", err)
 	}
 	return nil
-}
-
-type dateGroup struct {
-	Key   string
-	Texts []*text.Text
-}
-
-func byDate(texts []*text.Text) []*dateGroup {
-	aggregate := []*dateGroup{}
-
-	key := func(t time.Time) string {
-		return t.Format("January 2, 2006")
-	}
-
-	// Assumes texts are sorted by Timestamp descending.
-	var currentGroup *dateGroup
-	for _, t := range texts {
-		if k := key(t.Timestamp); currentGroup != nil && k == currentGroup.Key {
-			currentGroup.Texts = append(currentGroup.Texts, t)
-		} else {
-			currentGroup = &dateGroup{Key: k, Texts: []*text.Text{t}}
-			aggregate = append(aggregate, currentGroup)
-		}
-	}
-	return aggregate
 }

--- a/pkg/render/templates/html.tmpl
+++ b/pkg/render/templates/html.tmpl
@@ -1,7 +1,6 @@
 <head>
 	<title>tir</title>
     <meta charset="UTF-8">
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
     <link rel="icon" href="./static/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="./static/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="./static/favicon-32x32.png">
@@ -15,90 +14,131 @@
         }
 
         body {
-            margin-top: 140px;
-            margin-bottom: 140px;
+            margin-top: 3em;
+            margin-bottom: 3em;
         }
 
-        .title {
-            font-size: 70px; 
-            text-decoration: bold; 
-            color: #0074D9;
-            text-align: center;
-        }
-
-        h3 {
+        /* h3 {
             margin-top: 0px;
             margin-bottom: 0px;
             font-size: 12px;
             text-align: center;
-        }
-
-        p {
-            text-align: center;
-        }
+        } */
 
         /* Bodge: don't wrap dates. */
         table tbody tr td:nth-child(4) {
             white-space: nowrap;
         }
 
-        hr {
-            height: 2px;
-            background-color: #0074D9;
-            border: none;
-            width: 50%;
-            margin-top: 50px;
-            margin-bottom: 50px;
+        /* Tables (from blog) */
+        table {
+            margin: auto;
+            border-spacing: 0;
+        }
+
+        th, td {
+            padding: 0.5em;
+        }
+
+        th {
+            text-align: left;
+            border-bottom: 1px solid black;
+        }
+
+        tr:hover {
+            background-color: #f9f9f9;
+        }
+
+        .date {
+            text-align: right;
+            font-family: monospace;
+        }
+
+        /* Form */
+        details {
+            margin: 1em 0;
+            padding: 1em;
+            border: 1px dashed black;
+        }
+
+        form {
+            margin: 1em;
+        }
+
+        label {
+            display: block;
+            font-family: monospace;
+            font-size: small;
+            color: grey;
+        }
+
+        .form-group {
+            margin-bottom: 0.5em;
+        }
+
+        input {
+            width: 180px;
+        }
+
+        textarea {
+            width: 360px;
+            font-family: sans-serif;
         }
     </style>
 </head>
 
-<h1 class="title">tir</h1>
-<p><a href="https://github.com/lukasschwab/tiir">GitHub</a> &middot; <a href="/texts/feed.json">JSON Feed</a></p>
+<a href="https://github.com/lukasschwab/tiir">GitHub</a> &middot; <a href="/texts/feed.json">JSON Feed</a>
 
-<form id="textForm" 
-    hx-post="/texts" 
-    hx-target="this" 
-    hx-swap="none" 
-    hx-trigger="submit" 
-    hx-on="htmx:afterRequest: window.location.reload()"
->
-    <div class="form-group row">
-        <label for="url">URL</label>
-        <input type="url" class="form-control" id="url" name="url" placeholder="Enter URL" required>
-    </div>
-    <div class="form-group row">
-        <label for="author">Author</label>
-        <input type="text" class="form-control" id="author" name="author" placeholder="Enter Author" required>
-    </div>
-    <div class="form-group row">
-        <label for="title">Title</label>
-        <input type="text" class="form-control" id="title" name="title" placeholder="Enter Title" required>
-    </div>
-    <div class="form-group row">
-        <label for="note">Note</label>
-        <textarea class="form-control" id="note" name="note" placeholder="Enter Note" rows="3"></textarea>
-    </div>
-    <button type="submit" class="btn btn-primary">Submit</button>
-</form>
+<header>
+    <h1>tir</h1>
+</header>
 
-<hr/>
+<details>
+    <summary>Create a new text...</summary>
+    <form id="textForm" 
+        hx-post="/texts" 
+        hx-target="this" 
+        hx-swap="none" 
+        hx-trigger="submit" 
+        hx-on="htmx:afterRequest: window.location.reload()"
+    >
+        <div class="form-group">
+            <label for="url">URL</label>
+            <input type="url" class="form-control" id="url" name="url" required>
+        </div>
+        <div class="form-group">
+            <label for="title">Title</label>
+            <input type="text" class="form-control" id="title" name="title" required>
+        </div>
+        <div class="form-group">
+            <label for="author">Author</label>
+            <input type="text" class="form-control" id="author" name="author" required>
+        </div>
+        <div class="form-group">
+            <label for="note">Note</label>
+            <textarea class="form-control" id="note" name="note" rows="3"></textarea>
+        </div>
+        <label>Submit</label>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+</details>
 
 <table class="table">
     <tr>
         <th>Title</th>
         <th>Author</th>
         <th>Note</th>
-        <th>Date</th>
+        <th class="date">Date</th>
     </tr>
     {{ range . }}
-        <td colspan="4"><h3>{{ .Key }}</h3></td>
+        <!-- <td colspan="4" class="divider" style="border-bottom: 1px solid black;"></td> -->
+        <!-- <td colspan="4"><h3>{{ .Key }}</h3></td> -->
         {{range .Texts}}
-            <tr>
+            <tr id="{{.ID}}">
                 <td><a href="{{.URL}}">{{.Title}}</a></td>
                 <td>{{.Author}}</td>
                 <td>{{.Note}}</td>
-                <td>{{printf "%d-%02d-%02d" (.Timestamp.Year) (.Timestamp.Month) (.Timestamp.Day)}}</td>
+                <td class="date">{{printf "%d-%02d-%02d" (.Timestamp.Year) (.Timestamp.Month) (.Timestamp.Day)}}</td>
             </tr>
         {{end}}
     {{ end }}

--- a/pkg/render/templates/html.tmpl
+++ b/pkg/render/templates/html.tmpl
@@ -18,13 +18,6 @@
             margin-bottom: 3em;
         }
 
-        /* h3 {
-            margin-top: 0px;
-            margin-bottom: 0px;
-            font-size: 12px;
-            text-align: center;
-        } */
-
         /* Bodge: don't wrap dates. */
         table tbody tr td:nth-child(4) {
             white-space: nowrap;
@@ -77,11 +70,11 @@
         }
 
         input {
-            width: 180px;
+            width: 180px;   /* Arbitrary */
         }
 
         textarea {
-            width: 360px;
+            width: 360px;   /* Arbitrary */
             font-family: sans-serif;
         }
     </style>
@@ -131,16 +124,12 @@
         <th class="date">Date</th>
     </tr>
     {{ range . }}
-        <!-- <td colspan="4" class="divider" style="border-bottom: 1px solid black;"></td> -->
-        <!-- <td colspan="4"><h3>{{ .Key }}</h3></td> -->
-        {{range .Texts}}
-            <tr id="{{.ID}}">
-                <td><a href="{{.URL}}">{{.Title}}</a></td>
-                <td>{{.Author}}</td>
-                <td>{{.Note}}</td>
-                <td class="date">{{printf "%d-%02d-%02d" (.Timestamp.Year) (.Timestamp.Month) (.Timestamp.Day)}}</td>
-            </tr>
-        {{end}}
+        <tr id="{{.ID}}">
+            <td><a href="{{.URL}}">{{.Title}}</a></td>
+            <td>{{.Author}}</td>
+            <td>{{.Note}}</td>
+            <td class="date">{{printf "%d-%02d-%02d" (.Timestamp.Year) (.Timestamp.Month) (.Timestamp.Day)}}</td>
+        </tr>
     {{ end }}
 </table>
 

--- a/pkg/render/templates/html.tmpl
+++ b/pkg/render/templates/html.tmpl
@@ -89,11 +89,8 @@
 <details>
     <summary>Create a new text...</summary>
     <form id="textForm" 
-        hx-post="/texts" 
-        hx-target="this" 
-        hx-swap="none" 
-        hx-trigger="submit" 
-        hx-on="htmx:afterRequest: window.location.reload()"
+        action="/texts" method="post" target="oubliette"
+        onsubmit="this.submit(); window.location.reload(); return false;"
     >
         <div class="form-group">
             <label for="url">URL</label>
@@ -114,6 +111,8 @@
         <label>Submit</label>
         <button type="submit" class="btn btn-primary">Submit</button>
     </form>
+    <!-- Direct the AJAX response to this hidden iframe: prevent replacing DOM with JSON. -->
+    <iframe name="oubliette" style="display: none;"></iframe>
 </details>
 
 <table class="table">
@@ -132,5 +131,3 @@
         </tr>
     {{ end }}
 </table>
-
-<script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>

--- a/pkg/render/templates/html.tmpl
+++ b/pkg/render/templates/html.tmpl
@@ -56,6 +56,32 @@
 <h1 class="title">tir</h1>
 <p><a href="https://github.com/lukasschwab/tiir">GitHub</a> &middot; <a href="/texts/feed.json">JSON Feed</a></p>
 
+<form id="textForm" 
+    hx-post="/texts" 
+    hx-target="this" 
+    hx-swap="none" 
+    hx-trigger="submit" 
+    hx-on="htmx:afterRequest: window.location.reload()"
+>
+    <div class="form-group row">
+        <label for="url">URL</label>
+        <input type="url" class="form-control" id="url" name="url" placeholder="Enter URL" required>
+    </div>
+    <div class="form-group row">
+        <label for="author">Author</label>
+        <input type="text" class="form-control" id="author" name="author" placeholder="Enter Author" required>
+    </div>
+    <div class="form-group row">
+        <label for="title">Title</label>
+        <input type="text" class="form-control" id="title" name="title" placeholder="Enter Title" required>
+    </div>
+    <div class="form-group row">
+        <label for="note">Note</label>
+        <textarea class="form-control" id="note" name="note" placeholder="Enter Note" rows="3"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+
 <hr/>
 
 <table class="table">
@@ -77,3 +103,5 @@
         {{end}}
     {{ end }}
 </table>
+
+<script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>


### PR DESCRIPTION
# Changes

+ Redirects `/` to `/texts` for convenience.
+ Adds a form for creating new texts to the HTML template.
+ Eliminates dependency on bootstrap. Restyles to roughly match lukasschwab.me/blog.

## Notes

+ This form is junk data outside of an interactive browser, but I the only reasons to omit it are philosophical: I'm the sole user here.
- [x] Is HTMX really necessary? Can this use a raw HTML form instead?
    - It was not necessary, but would be neater if I wanted to reload the texts table dynamically and serve a static file instead of a Go-rendered template.
- [x] Look into hosting on Tailscale.